### PR TITLE
Feature/au 03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ out/
 # H2 Database
 *.mv.db
 *.trace.db
+
+# Secret
+application-secret.yaml

--- a/src/main/java/com/back/together02be/global/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/back/together02be/global/exceptionHandler/GlobalExceptionHandler.java
@@ -57,7 +57,6 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ApiRes<Void>> handleException(Exception e) {
-		e.printStackTrace();
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ApiRes<>("서버 오류가 발생했습니다.", null));
 	}

--- a/src/main/java/com/back/together02be/global/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/back/together02be/global/exceptionHandler/GlobalExceptionHandler.java
@@ -57,6 +57,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ApiRes<Void>> handleException(Exception e) {
+		e.printStackTrace();
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(new ApiRes<>("서버 오류가 발생했습니다.", null));
 	}

--- a/src/main/java/com/back/together02be/global/initData/BaseInitData.java
+++ b/src/main/java/com/back/together02be/global/initData/BaseInitData.java
@@ -1,5 +1,7 @@
 package com.back.together02be.global.initData;
 
+import com.back.together02be.users.dto.request.UsersReq;
+import com.back.together02be.users.service.UsersService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
@@ -20,16 +22,27 @@ public class BaseInitData {
 	@Lazy
 	private BaseInitData self;
 
+	private final UsersService usersService;
+
 	@Bean
-	//work1 실행하기.
 	public ApplicationRunner initData() {
 		return args -> {
 			self.work1();
+			self.work2();
 		};
 	}
 
 	@Transactional
 	public void work1() {
+	}
+
+	@Transactional
+	public void work2() {
+		if (usersService.count() > 0) return;
+
+		usersService.signup(new UsersReq("user1", "1234", "1234", "유저1"));
+		usersService.signup(new UsersReq("user2", "1234", "1234", "유저2"));
+		usersService.signup(new UsersReq("user3", "1234", "1234", "유저3"));
 	}
 
 }

--- a/src/main/java/com/back/together02be/global/util/JwtUtil.java
+++ b/src/main/java/com/back/together02be/global/util/JwtUtil.java
@@ -1,0 +1,68 @@
+package com.back.together02be.global.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ClaimsBuilder;
+import io.jsonwebtoken.Jwts;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+import io.jsonwebtoken.security.Keys;
+
+public class JwtUtil {
+
+    public static String generateAccessToken(String secret, long expireSeconds, Map<String, Object> body) {
+        ClaimsBuilder claimsBuilder = Jwts.claims();
+
+        for (Map.Entry<String, Object> entry : body.entrySet()) {
+            claimsBuilder.add(entry.getKey(), entry.getValue());
+        }
+
+        Claims claims = claimsBuilder.build();
+
+        Date issuedAt = new Date();
+        Date expiration = new Date(issuedAt.getTime() + 1000L * expireSeconds);
+
+        Key secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(issuedAt)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public static boolean isValid(String token, String secret) {
+        SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parse(token)
+                    .getPayload();
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public static Map<String, Object> payloadOrNull(String token, String secret) {
+        SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+
+        if (isValid(token, secret)) {
+            return (Map<String, Object>) Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parse(token)
+                    .getPayload();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/back/together02be/users/controller/UsersController.java
+++ b/src/main/java/com/back/together02be/users/controller/UsersController.java
@@ -33,7 +33,7 @@ public class UsersController {
     @PostMapping("/login")
     @Operation(summary = "로그인")
     public ResponseEntity<ApiRes<UsersRes>> login(@RequestBody LoginReq req) {
-        String accessToken = usersService.login(req);
-        return ResponseEntity.ok(new ApiRes<>("로그인 성공", new UsersRes(accessToken)));
+        String[] tokens = usersService.login(req);
+        return ResponseEntity.ok(new ApiRes<>("로그인 성공", new UsersRes(tokens[0], tokens[1])));
     }
 }

--- a/src/main/java/com/back/together02be/users/controller/UsersController.java
+++ b/src/main/java/com/back/together02be/users/controller/UsersController.java
@@ -1,7 +1,9 @@
 package com.back.together02be.users.controller;
 
 import com.back.together02be.global.apiRes.ApiRes;
+import com.back.together02be.users.dto.request.LoginReq;
 import com.back.together02be.users.dto.request.UsersReq;
+import com.back.together02be.users.dto.response.UsersRes;
 import com.back.together02be.users.service.UsersService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
@@ -26,5 +28,12 @@ public class UsersController {
     public ResponseEntity<ApiRes<Void>> signup(@RequestBody UsersReq req) {
         usersService.signup(req);
         return ResponseEntity.ok(new ApiRes<>("회원가입 성공", null));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인")
+    public ResponseEntity<ApiRes<UsersRes>> login(@RequestBody LoginReq req) {
+        String accessToken = usersService.login(req);
+        return ResponseEntity.ok(new ApiRes<>("로그인 성공", new UsersRes(accessToken)));
     }
 }

--- a/src/main/java/com/back/together02be/users/dto/request/LoginReq.java
+++ b/src/main/java/com/back/together02be/users/dto/request/LoginReq.java
@@ -1,0 +1,6 @@
+package com.back.together02be.users.dto.request;
+
+public record LoginReq(
+        String username,
+        String password
+) {}

--- a/src/main/java/com/back/together02be/users/dto/response/LoginRes.java
+++ b/src/main/java/com/back/together02be/users/dto/response/LoginRes.java
@@ -1,0 +1,5 @@
+package com.back.together02be.users.dto.response;
+
+public record LoginRes (
+        String accessToken
+) {}

--- a/src/main/java/com/back/together02be/users/dto/response/UsersRes.java
+++ b/src/main/java/com/back/together02be/users/dto/response/UsersRes.java
@@ -1,5 +1,6 @@
 package com.back.together02be.users.dto.response;
 
 public record UsersRes(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {}

--- a/src/main/java/com/back/together02be/users/entity/Users.java
+++ b/src/main/java/com/back/together02be/users/entity/Users.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -21,10 +23,25 @@ public class Users extends BaseEntity {
 	@Column(nullable = false, length = 30)
 	private String nickname;
 
+	@Column(unique = true)
+	private String refreshToken;
+
+	private LocalDateTime refreshTokenExpiration;
+
 	public Users(String username, String password, String nickname) {
 		this.username = username;
 		this.password = password;
 		this.nickname = nickname;
+	}
+
+	public void updateRefreshToken(String refreshToken, LocalDateTime expiration) {
+		this.refreshToken = refreshToken;
+		this.refreshTokenExpiration = expiration;
+	}
+
+	public void clearRefreshToken() {
+		this.refreshToken = null;
+		this.refreshTokenExpiration = null;
 	}
 
 }

--- a/src/main/java/com/back/together02be/users/entity/Users.java
+++ b/src/main/java/com/back/together02be/users/entity/Users.java
@@ -34,11 +34,13 @@ public class Users extends BaseEntity {
 		this.nickname = nickname;
 	}
 
+	// 리프레시 토큰 설정
 	public void updateRefreshToken(String refreshToken, LocalDateTime expiration) {
 		this.refreshToken = refreshToken;
 		this.refreshTokenExpiration = expiration;
 	}
 
+	// 리프레시 토큰 초기화
 	public void clearRefreshToken() {
 		this.refreshToken = null;
 		this.refreshTokenExpiration = null;

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -41,6 +41,10 @@ public class UsersService {
         usersRepository.save(user);
     }
 
+    public long count() {
+        return usersRepository.count();
+    }
+
     public String login(LoginReq req) {
         Users user = usersRepository.findByUsername(req.username())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +50,7 @@ public class UsersService {
         return usersRepository.count();
     }
 
+    @Transactional
     public String[] login(LoginReq req) {
         Users user = usersRepository.findByUsername(req.username())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
@@ -61,11 +64,10 @@ public class UsersService {
                 accessExpireSeconds,
                 Map.of("username", user.getUsername())
         );
-        String refreshToken = JwtUtil.generateAccessToken(
-                jwtSecret,
-                refreshExpireSeconds,
-                Map.of("username", user.getUsername())
-        );
+
+        String refreshToken = UUID.randomUUID().toString();
+        LocalDateTime refreshTokenExpiration = LocalDateTime.now().plusSeconds(refreshExpireSeconds);
+        user.updateRefreshToken(refreshToken, refreshTokenExpiration);
 
         return new String[]{accessToken, refreshToken};
     }

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -1,18 +1,29 @@
 package com.back.together02be.users.service;
 
+import com.back.together02be.global.util.JwtUtil;
+import com.back.together02be.users.dto.request.LoginReq;
 import com.back.together02be.users.dto.request.UsersReq;
 import com.back.together02be.users.entity.Users;
 import com.back.together02be.users.repository.UsersRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class UsersService {
 
     private final UsersRepository usersRepository;
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expire-seconds}")
+    private long jwtExpireSeconds;
 
     @Transactional
     public void signup(UsersReq req) {
@@ -28,5 +39,16 @@ public class UsersService {
         // db에 [회원가입 한 user] 저장
         Users user = new Users(req.username(), req.password(), req.nickname());
         usersRepository.save(user);
+    }
+
+    public String login(LoginReq req) {
+        Users user = usersRepository.findByUsername(req.username())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
+
+        if (!req.password().equals(user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        return JwtUtil.generateAccessToken(jwtSecret, jwtExpireSeconds, Map.of("username", user.getUsername()));
     }
 }

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -22,8 +22,11 @@ public class UsersService {
     @Value("${jwt.secret}")
     private String jwtSecret;
 
-    @Value("${jwt.expire-seconds}")
-    private long jwtExpireSeconds;
+    @Value("${jwt.access-expire-seconds}")
+    private long accessExpireSeconds;
+
+    @Value("${jwt.refresh-expire-seconds}")
+    private long refreshExpireSeconds;
 
     @Transactional
     public void signup(UsersReq req) {
@@ -45,7 +48,7 @@ public class UsersService {
         return usersRepository.count();
     }
 
-    public String login(LoginReq req) {
+    public String[] login(LoginReq req) {
         Users user = usersRepository.findByUsername(req.username())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
 
@@ -53,6 +56,17 @@ public class UsersService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        return JwtUtil.generateAccessToken(jwtSecret, jwtExpireSeconds, Map.of("username", user.getUsername()));
+        String accessToken = JwtUtil.generateAccessToken(
+                jwtSecret,
+                accessExpireSeconds,
+                Map.of("username", user.getUsername())
+        );
+        String refreshToken = JwtUtil.generateAccessToken(
+                jwtSecret,
+                refreshExpireSeconds,
+                Map.of("username", user.getUsername())
+        );
+
+        return new String[]{accessToken, refreshToken};
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,10 @@ spring:
       ddl-auto: create-drop
     show-sql: true
 
+jwt:
+  secret: "your-secret-key-change-this-in-production-must-be-long-enough"
+  expire-seconds: 3600
+
 springdoc:
   default-produces-media-type: application/json; charset=UTF-8
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,8 @@ spring:
 
 jwt:
   secret: "your-secret-key-change-this-in-production-must-be-long-enough"
-  expire-seconds: 3600
+  access-expire-seconds: 3600
+  refresh-expire-seconds: 1209600
 
 springdoc:
   default-produces-media-type: application/json; charset=UTF-8

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ spring:
   application:
     name: together-02-be
 
+  profiles:
+    include: secret
+
   datasource:
     url: jdbc:h2:mem:db_dev;MODE=MySQL
     username: sa
@@ -23,7 +26,6 @@ spring:
     show-sql: true
 
 jwt:
-  secret: "your-secret-key-change-this-in-production-must-be-long-enough"
   access-expire-seconds: 3600
   refresh-expire-seconds: 1209600
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,8 +26,8 @@ spring:
     show-sql: true
 
 jwt:
-  access-expire-seconds: 3600
-  refresh-expire-seconds: 1209600
+  access-expire-seconds: 900
+  refresh-expire-seconds: 604800
 
 springdoc:
   default-produces-media-type: application/json; charset=UTF-8


### PR DESCRIPTION
## 📌 과제 설명
  로그인 기능과 리프레시 토큰 발급 구현
  `POST /api/users/login` 엔드포인트를 통해 인증 후 액세스 토큰(JWT) & 리프레시 토큰(UUID) 발급

  ## 👩‍💻 요구 사항과 구현 내용
  **feat: 로그인 기능 구현**
  - `LoginReq` DTO 생성 (`username`, `password`)
  - `JwtUtil` 구현 (`generateAccessToken`, `isValid`, `payloadOrNull`)
  - `application-secret.yaml`로 JWT secret 키 분리
  - `UsersService.login()` 구현 — 아이디/비밀번호 검증 후 액세스 토큰 발급
  - `UsersController`에 `POST /api/users/login` 엔드포인트 추가

  **feat: 로그인 테스트 초기 유저 데이터 추가**
  - `BaseInitData.work2()`에 초기 유저 3건 삽입
  - `UsersService.count()`로 데이터 없을 때만 삽입하도록 처리
  - `InitData` → `Repository` 직접 참조 대신 `Service` 통해 접근하도록 변경

  **feat: 리프레시 토큰 발급 추가**
  - `UsersRes`에 `refreshToken` 필드 추가
  - 로그인 응답에 액세스 토큰 + 리프레시 토큰 같이 반환

  **feat: Users 엔티티에 리프레시 토큰 필드 추가**
  - `refreshToken` (UUID), `refreshTokenExpiration` 필드 추가
  - `updateRefreshToken()`, `clearRefreshToken()` 메서드 추가

  **feat: 로그인 시 UUID 리프레시 토큰 생성 후 DB 저장**
  - 리프레시 토큰을 JWT 대신 UUID로 변경
  - 로그인 시 UUID 생성 후 `Users` 테이블에 저장

  **chore: JWT 토큰 만료 시간 설정**
  - 액세스 토큰: 15분
  - 리프레시 토큰: 7일

  ## ✅ PR 포인트 & 궁금한 점
  - 리프레시 토큰은 별도 테이블 대신 `Users` 테이블에 저장했는데, 만약 추후에 다중 기기 로그인을 고려한다면 따로 리프레시 토큰 테이블을 만드는 것이 좋아 보입니다.
  - 액세스 토큰을 UUID로 하게 되면 API요청마다 DB를 조회해서 유효한 토큰인지 매번 확인해 주어야 해서, JWT로 확정했습니다. (JWT는 DB없이 확인 가능해 훨씬 빠릅니다.)
  - JWT secret 키는 `application-secret.yaml`로 분리했습니다. 해당 파일을 로컬에서 직접 생성해주셔야 합니다.