### PR TITLE
Feature/au 07

### DIFF
--- a/src/main/java/com/back/together02be/global/initData/BaseInitData.java
+++ b/src/main/java/com/back/together02be/global/initData/BaseInitData.java
@@ -1,6 +1,6 @@
 package com.back.together02be.global.initData;
 
-import com.back.together02be.users.dto.request.UsersReq;
+import com.back.together02be.users.dto.request.SignupReq;
 import com.back.together02be.users.service.UsersService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
@@ -40,9 +40,9 @@ public class BaseInitData {
 	public void work2() {
 		if (usersService.count() > 0) return;
 
-		usersService.signup(new UsersReq("user1", "1234", "1234", "유저1"));
-		usersService.signup(new UsersReq("user2", "1234", "1234", "유저2"));
-		usersService.signup(new UsersReq("user3", "1234", "1234", "유저3"));
+		usersService.signup(new SignupReq("user1", "1234", "1234", "유저1"));
+		usersService.signup(new SignupReq("user2", "1234", "1234", "유저2"));
+		usersService.signup(new SignupReq("user3", "1234", "1234", "유저3"));
 	}
 
 }

--- a/src/main/java/com/back/together02be/users/controller/UsersController.java
+++ b/src/main/java/com/back/together02be/users/controller/UsersController.java
@@ -2,7 +2,8 @@ package com.back.together02be.users.controller;
 
 import com.back.together02be.global.apiRes.ApiRes;
 import com.back.together02be.users.dto.request.LoginReq;
-import com.back.together02be.users.dto.request.UsersReq;
+import com.back.together02be.users.dto.request.TokenReq;
+import com.back.together02be.users.dto.request.SignupReq;
 import com.back.together02be.users.dto.response.UsersRes;
 import com.back.together02be.users.service.UsersService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,15 +26,25 @@ public class UsersController {
 
     @PostMapping("/signup")
     @Operation(summary = "회원 가입")
-    public ResponseEntity<ApiRes<Void>> signup(@RequestBody UsersReq req) {
+    public ResponseEntity<ApiRes<Void>> signup(@RequestBody SignupReq req) {
         usersService.signup(req);
         return ResponseEntity.ok(new ApiRes<>("회원가입 성공", null));
     }
+
+    // tokens[0] : Access
+    // tokens[1] : Refresh
 
     @PostMapping("/login")
     @Operation(summary = "로그인")
     public ResponseEntity<ApiRes<UsersRes>> login(@RequestBody LoginReq req) {
         String[] tokens = usersService.login(req);
         return ResponseEntity.ok(new ApiRes<>("로그인 성공", new UsersRes(tokens[0], tokens[1])));
+    }
+
+    @PostMapping("/token")
+    @Operation(summary = "토큰 재발급")
+    public ResponseEntity<ApiRes<UsersRes>> reissueToken(@RequestBody TokenReq req) {
+        String[] tokens = usersService.reissueToken(req);
+        return ResponseEntity.ok(new ApiRes<>("토큰 재발급 성공", new UsersRes(tokens[0], tokens[1])));
     }
 }

--- a/src/main/java/com/back/together02be/users/dto/request/SignupReq.java
+++ b/src/main/java/com/back/together02be/users/dto/request/SignupReq.java
@@ -1,6 +1,6 @@
 package com.back.together02be.users.dto.request;
 
-public record UsersReq(
+public record SignupReq(
         String username,
         String password,
         String passwordConfirm,

--- a/src/main/java/com/back/together02be/users/dto/request/TokenReq.java
+++ b/src/main/java/com/back/together02be/users/dto/request/TokenReq.java
@@ -1,0 +1,5 @@
+package com.back.together02be.users.dto.request;
+
+public record TokenReq(
+        String refreshToken
+) {}

--- a/src/main/java/com/back/together02be/users/dto/response/LoginRes.java
+++ b/src/main/java/com/back/together02be/users/dto/response/LoginRes.java
@@ -1,5 +1,0 @@
-package com.back.together02be.users.dto.response;
-
-public record LoginRes (
-        String accessToken
-) {}

--- a/src/main/java/com/back/together02be/users/repository/UsersRepository.java
+++ b/src/main/java/com/back/together02be/users/repository/UsersRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUsername(String username);
+    Optional<Users> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -2,7 +2,8 @@ package com.back.together02be.users.service;
 
 import com.back.together02be.global.util.JwtUtil;
 import com.back.together02be.users.dto.request.LoginReq;
-import com.back.together02be.users.dto.request.UsersReq;
+import com.back.together02be.users.dto.request.TokenReq;
+import com.back.together02be.users.dto.request.SignupReq;
 import com.back.together02be.users.entity.Users;
 import com.back.together02be.users.repository.UsersRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +32,7 @@ public class UsersService {
     private long refreshExpireSeconds;
 
     @Transactional
-    public void signup(UsersReq req) {
+    public void signup(SignupReq req) {
 
         if (usersRepository.findByUsername(req.username()).isPresent()) {
             throw new IllegalArgumentException("이미 사용중인 아이디입니다.");
@@ -52,45 +53,59 @@ public class UsersService {
 
     @Transactional
     public String[] login(LoginReq req) {
-        Users user = usersRepository.findByUsername(req.username())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
+        Users user = usersRepository
+                .findByUsername(req.username())
+                .orElseThrow(
+                        () -> new IllegalArgumentException("존재하지 않는 아이디입니다.")
+                );
 
         if (!req.password().equals(user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
+        // AccessToken 발급
         String accessToken = JwtUtil.generateAccessToken(
                 jwtSecret,
                 accessExpireSeconds,
                 Map.of("username", user.getUsername())
         );
 
+        // RefreshToken 발급
         String refreshToken = UUID.randomUUID().toString();
-        LocalDateTime refreshTokenExpiration = LocalDateTime.now().plusSeconds(refreshExpireSeconds);
-        user.updateRefreshToken(refreshToken, refreshTokenExpiration);
+        user.updateRefreshToken(
+                refreshToken,
+                LocalDateTime.now().plusSeconds(refreshExpireSeconds)
+        );
 
         return new String[]{accessToken, refreshToken};
     }
 
     @Transactional
-    public String[] reissueToken(String refreshToken) {
-        Users user = usersRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."));
+    public String[] reissueToken(TokenReq req) {
+        Users user = usersRepository
+                .findByRefreshToken(req.refreshToken())
+                .orElseThrow(
+                        () -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.")
+                );
 
-        // 만료시간(10시) < 현재시간(11시) 일 경우
+        // 만료시간(10시) < 현재시간(11시)
         if (user.getRefreshTokenExpiration().isBefore(LocalDateTime.now())) {
             throw new IllegalArgumentException("리프레시 토큰이 만료되었습니다.");
         }
 
-        // 새로운 AccessToken 발급
+        // AccessToken 갱신
         String newAccessToken = JwtUtil.generateAccessToken(
                 jwtSecret,
                 accessExpireSeconds,
                 Map.of("username", user.getUsername())
         );
 
+        // RefreshToken 갱신
         String newRefreshToken = UUID.randomUUID().toString();
-        user.updateRefreshToken(newRefreshToken, LocalDateTime.now().plusSeconds(refreshExpireSeconds));
+        user.updateRefreshToken(
+                newRefreshToken,
+                LocalDateTime.now().plusSeconds(refreshExpireSeconds)
+        );
 
         return new String[]{newAccessToken, newRefreshToken};
     }

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -71,4 +71,27 @@ public class UsersService {
 
         return new String[]{accessToken, refreshToken};
     }
+
+    @Transactional
+    public String[] reissueToken(String refreshToken) {
+        Users user = usersRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."));
+
+        // 만료시간(10시) < 현재시간(11시) 일 경우
+        if (user.getRefreshTokenExpiration().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("리프레시 토큰이 만료되었습니다.");
+        }
+
+        // 새로운 AccessToken 발급
+        String newAccessToken = JwtUtil.generateAccessToken(
+                jwtSecret,
+                accessExpireSeconds,
+                Map.of("username", user.getUsername())
+        );
+
+        String newRefreshToken = UUID.randomUUID().toString();
+        user.updateRefreshToken(newRefreshToken, LocalDateTime.now().plusSeconds(refreshExpireSeconds));
+
+        return new String[]{newAccessToken, newRefreshToken};
+    }
 }


### PR DESCRIPTION
 ## 📌 과제 설명
  액세스 토큰 만료 시 리프레시 토큰으로 새 토큰을 재발급하는 API 구현.
  Refresh Token Rotation 방식으로 재발급 시 리프레시 토큰도 함께 재발급.

## 👩‍💻 요구 사항과 구현 내용
  **feat: UsersRepository에 findByRefreshToken() 추가**
  - 리프레시 토큰으로 유저를 조회하기 위한 메서드 추가

  **feat: UsersService에 reissueToken() 구현 (Rotation)**
  - 리프레시 토큰 유효성 검증 (DB 조회 + 만료 시간 확인)
  - 액세스 토큰 (JWT) 재발급
  - 리프레시 토큰 (UUID) 재발급 후 DB 업데이트 (Rotation)

  **feat: 토큰 재발급 엔드포인트 구현**
  - `TokenReq` DTO 생성 (`refreshToken` 생성해서 반환하기 위한 필드)
  - `UsersController`에 `POST /api/users/token` 엔드포인트 추가

## ✅ PR 포인트 & 궁금한 점
  - Refresh Token Rotation 방식을 적용해 재발급 시 기존에 사용하던 리프레시 토큰을 폐기하고 새 토큰을 발급해 저장하도록 했습니다.
  - 지금 리프레시 토큰은 Body로 전달받고 있는데, Spring Security 도입 시 Authorization 헤더 방식으로 변경해, Bearer 처리할 예정입니다.