### PR TITLE
Feature/au 05

### DIFF
--- a/src/main/java/com/back/together02be/global/util/JwtUtil.java
+++ b/src/main/java/com/back/together02be/global/util/JwtUtil.java
@@ -14,7 +14,11 @@ import io.jsonwebtoken.security.Keys;
 
 public class JwtUtil {
 
-    public static String generateAccessToken(String secret, long expireSeconds, Map<String, Object> body) {
+    public static String generateAccessToken(
+            String secret,
+            long expireSeconds,
+            Map<String, Object> body
+    ) {
         ClaimsBuilder claimsBuilder = Jwts.claims();
 
         for (Map.Entry<String, Object> entry : body.entrySet()) {
@@ -37,6 +41,7 @@ public class JwtUtil {
     }
 
     public static boolean isValid(String token, String secret) {
+
         SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
 
         try {
@@ -53,6 +58,7 @@ public class JwtUtil {
     }
 
     public static Map<String, Object> payloadOrNull(String token, String secret) {
+
         SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
 
         if (isValid(token, secret)) {

--- a/src/main/java/com/back/together02be/users/controller/UsersController.java
+++ b/src/main/java/com/back/together02be/users/controller/UsersController.java
@@ -27,24 +27,54 @@ public class UsersController {
     @PostMapping("/signup")
     @Operation(summary = "회원 가입")
     public ResponseEntity<ApiRes<Void>> signup(@RequestBody SignupReq req) {
+
         usersService.signup(req);
-        return ResponseEntity.ok(new ApiRes<>("회원가입 성공", null));
+        return ResponseEntity.ok(
+                new ApiRes<>(
+                        "회원가입 성공",
+                        null
+                )
+        );
     }
 
-    // tokens[0] : Access
-    // tokens[1] : Refresh
+    // tokens[0] : Access, tokens[1] : Refresh
 
     @PostMapping("/login")
     @Operation(summary = "로그인")
     public ResponseEntity<ApiRes<UsersRes>> login(@RequestBody LoginReq req) {
+
         String[] tokens = usersService.login(req);
-        return ResponseEntity.ok(new ApiRes<>("로그인 성공", new UsersRes(tokens[0], tokens[1])));
+        return ResponseEntity.ok(
+                new ApiRes<>(
+                        "로그인 성공",
+                        new UsersRes(tokens[0], tokens[1])
+                )
+        );
     }
 
     @PostMapping("/token")
     @Operation(summary = "토큰 재발급")
     public ResponseEntity<ApiRes<UsersRes>> reissueToken(@RequestBody TokenReq req) {
+
         String[] tokens = usersService.reissueToken(req);
-        return ResponseEntity.ok(new ApiRes<>("토큰 재발급 성공", new UsersRes(tokens[0], tokens[1])));
+        return ResponseEntity.ok(
+                new ApiRes<>(
+                        "토큰 재발급 성공",
+                        new UsersRes(tokens[0], tokens[1])
+                )
+        );
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃")
+    public ResponseEntity<ApiRes<Void>> logout(@RequestBody TokenReq req) {
+
+        usersService.logout(req);
+        return ResponseEntity.ok(
+                new ApiRes<>(
+                        "로그아웃 성공",
+                        null
+                )
+        );
     }
 }

--- a/src/main/java/com/back/together02be/users/service/UsersService.java
+++ b/src/main/java/com/back/together02be/users/service/UsersService.java
@@ -53,6 +53,7 @@ public class UsersService {
 
     @Transactional
     public String[] login(LoginReq req) {
+
         Users user = usersRepository
                 .findByUsername(req.username())
                 .orElseThrow(
@@ -81,7 +82,20 @@ public class UsersService {
     }
 
     @Transactional
+    public void logout(TokenReq req) {
+
+        Users user = usersRepository
+                .findByRefreshToken(req.refreshToken())
+                .orElseThrow(
+                        () -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.")
+                );
+
+        user.clearRefreshToken();
+    }
+
+    @Transactional
     public String[] reissueToken(TokenReq req) {
+
         Users user = usersRepository
                 .findByRefreshToken(req.refreshToken())
                 .orElseThrow(


### PR DESCRIPTION
## 📌 과제 설명
- 로그아웃 API 구현

## 👩‍💻 요구 사항과 구현 내용
- `UsersService`에 `logout()`메서드 구현
  - refreshToken으로 사용자를 조회 후 `clearRefreshToken()` 으로 DB의 토큰 무효화
- `UsersController`에 `POST /api/users/logout` 엔드포인트 추가
  - `TokenReq`를 응답으로 받아(유저 확인 완료) 로그아웃 후 성공 메시지 반환

## ✅ PR 포인트 & 궁금한 점
- 로그아웃 메서드 구현할 때 username 대신 refreshToken으로 사용자를 조회했습니다.
  - refreshToken 자체가 유저를 구별하는 고유 값이고, 로그아웃 자체가 리프레시 토큰의 무효화입니다.
  - 나중에 멀티 디바이스 확장할 때도 유리한 구조입니다. (username으로 찾아서 날리면 모든 세션에서 전부 로그아웃되므로)