### PR TITLE
Feature/st 03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 # H2 Database
 *.mv.db
 *.trace.db
+
+# api key
+application-local.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testAnnotationProcessor("org.projectlombok:lombok")
+    implementation("org.java-websocket:Java-WebSocket:1.6.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/together02be/asset/enitity/UserStock.java
+++ b/src/main/java/com/back/together02be/asset/enitity/UserStock.java
@@ -1,7 +1,7 @@
 package com.back.together02be.asset.enitity;
 
 import com.back.together02be.global.entity.BaseEntity;
-import com.back.together02be.stock.enitity.Stock;
+import com.back.together02be.stock.entity.Stock;
 import com.back.together02be.users.enitity.Users;
 
 import jakarta.persistence.Column;

--- a/src/main/java/com/back/together02be/infra/kis/ApprovalKeyService.java
+++ b/src/main/java/com/back/together02be/infra/kis/ApprovalKeyService.java
@@ -1,0 +1,43 @@
+package com.back.together02be.infra.kis;
+
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import com.back.together02be.infra.kis.config.KisProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApprovalKeyService {
+
+	private final KisProperties kisProperties;
+	private final RestClient restClient;
+
+	// https://apiportal.koreainvestment.com/apiservice-apiservice?/oauth2/Approval
+	public String getApprovalKey() {
+		Map<String, String> requestBody = Map.of(
+			"grant_type", "client_credentials",
+			"appkey", kisProperties.getAppKey(),
+			"secretkey", kisProperties.getAppSecret()
+		);
+
+		Map<String, String> response = restClient.post()
+			.uri(kisProperties.getRestBaseUrl() + "/oauth2/Approval")
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(requestBody)
+			.retrieve()
+			.body(new ParameterizedTypeReference<>() {});
+
+		String approvalKey = response.get("approval_key");
+		log.info("approval_key 발급 완료: {}", approvalKey);
+		return approvalKey;
+	}
+
+}

--- a/src/main/java/com/back/together02be/infra/kis/KisWebSocketClient.java
+++ b/src/main/java/com/back/together02be/infra/kis/KisWebSocketClient.java
@@ -1,0 +1,61 @@
+package com.back.together02be.infra.kis;
+
+import java.net.URI;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.springframework.stereotype.Component;
+
+import com.back.together02be.infra.kis.config.KisProperties;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisWebSocketClient {
+
+	private final KisProperties kisProperties;
+	private final ApprovalKeyService approvalKeyService;
+	private final KisWebSocketHandler handler;
+
+	private WebSocketClient client;
+
+	@PostConstruct
+	public void connect() throws Exception {
+		String approvalKey = approvalKeyService.getApprovalKey();
+		handler.setApprovalKey(approvalKey);
+
+		client = new WebSocketClient(new URI(kisProperties.getWsUrl())) {
+
+			@Override
+			public void onOpen(ServerHandshake handshake) {
+				log.info("한국투자 증권 WebSocket 연결 성공");
+				handler.onOpen(this);
+			}
+
+			@Override
+			public void onMessage(String message) {
+				handler.onMessage(message);
+			}
+
+			@Override
+			public void onClose(int code, String reason, boolean remote) {
+				log.warn("WebSocket 연결 종료 - code: {}, reason: {}", code, reason);
+			}
+
+			@Override
+			public void onError(Exception e) {
+				log.error("WebSocket 오류", e);
+			}
+		};
+
+		client.connectBlocking();
+	}
+
+	public void subscribe(String stockCode) {
+		handler.subscribe(client, stockCode);
+	}
+}

--- a/src/main/java/com/back/together02be/infra/kis/KisWebSocketClient.java
+++ b/src/main/java/com/back/together02be/infra/kis/KisWebSocketClient.java
@@ -58,4 +58,8 @@ public class KisWebSocketClient {
 	public void subscribe(String stockCode) {
 		handler.subscribe(client, stockCode);
 	}
+
+	public void unsubscribe(String stockCode) {
+		handler.unsubscribe(client, stockCode);
+	}
 }

--- a/src/main/java/com/back/together02be/infra/kis/KisWebSocketHandler.java
+++ b/src/main/java/com/back/together02be/infra/kis/KisWebSocketHandler.java
@@ -1,0 +1,71 @@
+package com.back.together02be.infra.kis;
+
+import org.java_websocket.WebSocket;
+import org.springframework.stereotype.Component;
+
+import com.back.together02be.infra.kis.constant.KisConstants;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class KisWebSocketHandler {
+
+	private String approvalKey;
+
+	public void setApprovalKey(String approvalKey) {
+		this.approvalKey = approvalKey;
+	}
+
+	public void onOpen(WebSocket conn) {
+		// 삼성전자 구독 (테스트용)
+		subscribe(conn, "005930");
+	}
+
+	public void subscribe(WebSocket conn, String stockCode) {
+		String message = """
+			{
+			  "header": {
+			    "approval_key": "%s",
+			    "custtype": "P",
+			    "tr_type": "1",
+			    "content-type": "utf-8"
+			  },
+			  "body": {
+			    "input": {
+			      "tr_id": "%s",
+			      "tr_key": "%s"
+			    }
+			  }
+			}
+			""".formatted(approvalKey, KisConstants.TR_REALTIME_PRICE, stockCode);
+
+		conn.send(message);
+		log.info("구독 시작: {}", stockCode);
+	}
+
+	public void onMessage(String message) {
+		if (message.startsWith("{")) {
+			log.info("제어 메시지: {}", message);
+			return;
+		}
+		parse(message);
+	}
+
+	private void parse(String raw) {
+		String[] parts = raw.split("\\|");
+		if (parts.length < 4)
+			return;
+
+		String[] fields = parts[3].split("\\^");
+
+		String stockCode = fields[KisConstants.FIELD_STOCK_CODE]; // 종목 코드
+		String price = fields[KisConstants.FIELD_CURRENT_PRICE]; // 주식 현재가
+		String changeSign = fields[KisConstants.FIELD_CHANGE_SIGN]; // 전일 대비 부호
+		String priceChange = fields[KisConstants.FIELD_CHANGE]; // 전일 대비
+		String priceChangeRate = fields[KisConstants.FIELD_CHANGE_RATE]; // 전일 대비율
+
+		log.info("[{}] 현재가: {}원 | 전일 대비 부호: {} | 전일 대비 가격: {} | 전일 대비율: {}",
+			stockCode, price, changeSign, priceChange, priceChangeRate);
+	}
+}

--- a/src/main/java/com/back/together02be/infra/kis/KisWebSocketHandler.java
+++ b/src/main/java/com/back/together02be/infra/kis/KisWebSocketHandler.java
@@ -4,12 +4,18 @@ import org.java_websocket.WebSocket;
 import org.springframework.stereotype.Component;
 
 import com.back.together02be.infra.kis.constant.KisConstants;
+import com.back.together02be.stock.dto.RealtimeStockPrice;
+import com.back.together02be.stock.service.RealTimeStockPriceStore;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class KisWebSocketHandler {
+
+	private final RealTimeStockPriceStore rtStockPriceStore;
 
 	private String approvalKey;
 
@@ -18,8 +24,7 @@ public class KisWebSocketHandler {
 	}
 
 	public void onOpen(WebSocket conn) {
-		// 삼성전자 구독 (테스트용)
-		subscribe(conn, "005930");
+		log.info("한국투자 증권 WebSocket 연결 성공");
 	}
 
 	public void subscribe(WebSocket conn, String stockCode) {
@@ -44,6 +49,28 @@ public class KisWebSocketHandler {
 		log.info("구독 시작: {}", stockCode);
 	}
 
+	public void unsubscribe(WebSocket conn, String stockCode) {
+		String message = """
+        {
+          "header": {
+            "approval_key": "%s",
+            "custtype": "P",
+            "tr_type": "2",
+            "content-type": "utf-8"
+          },
+          "body": {
+            "input": {
+              "tr_id": "%s",
+              "tr_key": "%s"
+            }
+          }
+        }
+        """.formatted(approvalKey, KisConstants.TR_REALTIME_PRICE, stockCode);
+
+		conn.send(message);
+		log.info("구독 취소: {}", stockCode);
+	}
+
 	public void onMessage(String message) {
 		if (message.startsWith("{")) {
 			log.info("제어 메시지: {}", message);
@@ -53,19 +80,25 @@ public class KisWebSocketHandler {
 	}
 
 	private void parse(String raw) {
+		// 포맷: 0|H0STCNT0|004|005930^150000^70800^...
 		String[] parts = raw.split("\\|");
 		if (parts.length < 4)
 			return;
 
 		String[] fields = parts[3].split("\\^");
 
-		String stockCode = fields[KisConstants.FIELD_STOCK_CODE]; // 종목 코드
-		String price = fields[KisConstants.FIELD_CURRENT_PRICE]; // 주식 현재가
-		String changeSign = fields[KisConstants.FIELD_CHANGE_SIGN]; // 전일 대비 부호
-		String priceChange = fields[KisConstants.FIELD_CHANGE]; // 전일 대비
-		String priceChangeRate = fields[KisConstants.FIELD_CHANGE_RATE]; // 전일 대비율
+		RealtimeStockPrice stockPrice = RealtimeStockPrice.builder()
+			.stockCode(fields[KisConstants.FIELD_STOCK_CODE]) // 종목 코드
+			.tradeTime(fields[KisConstants.FIELD_TRADE_TIME]) // 체결 시간
+			.price(fields[KisConstants.FIELD_CURRENT_PRICE]) // 주식 현재가
+			.changeSign(fields[KisConstants.FIELD_CHANGE_SIGN]) // 전일 대비 부호
+			.change(fields[KisConstants.FIELD_CHANGE]) // 전일 대비
+			.changeRate(fields[KisConstants.FIELD_CHANGE_RATE]) // 전일 대비율
+			.build();
 
-		log.info("[{}] 현재가: {}원 | 전일 대비 부호: {} | 전일 대비 가격: {} | 전일 대비율: {}",
-			stockCode, price, changeSign, priceChange, priceChangeRate);
+		rtStockPriceStore.put(stockPrice.getStockCode(), stockPrice); // ← 캐싱
+		log.info("[{}] 체결시간: {}, 현재가: {}원 | 전일 대비 부호: {} | 전일 대비 가격: {} | 전일 대비율: {}",
+			stockPrice.getStockCode(), stockPrice.getTradeTime(), stockPrice.getPrice(), stockPrice.getChangeSign(),
+			stockPrice.getChange(), stockPrice.getChangeRate());
 	}
 }

--- a/src/main/java/com/back/together02be/infra/kis/config/KisConfig.java
+++ b/src/main/java/com/back/together02be/infra/kis/config/KisConfig.java
@@ -1,0 +1,13 @@
+package com.back.together02be.infra.kis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class KisConfig {
+	@Bean
+	public RestClient restClient() {
+		return RestClient.create();
+	}
+}

--- a/src/main/java/com/back/together02be/infra/kis/config/KisProperties.java
+++ b/src/main/java/com/back/together02be/infra/kis/config/KisProperties.java
@@ -1,0 +1,18 @@
+package com.back.together02be.infra.kis.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "kis")
+public class KisProperties {
+	private String appKey;
+	private String appSecret;
+	private String restBaseUrl;
+	private String wsUrl;
+}

--- a/src/main/java/com/back/together02be/infra/kis/constant/KisConstants.java
+++ b/src/main/java/com/back/together02be/infra/kis/constant/KisConstants.java
@@ -5,8 +5,9 @@ public class KisConstants {
 
 	// H0STCNT0 수신 필드 인덱스('^' 구분)
 	public static final int FIELD_STOCK_CODE    	 = 0;  // MKSC_SHRN_ISCD, 종목 코드
+	public static final int FIELD_TRADE_TIME		 = 1;  // STCK_CNTG_HOUR, 주식 체결 시간
 	public static final int FIELD_CURRENT_PRICE      = 2;  // STCK_PRPR, 주식 현재가
-	public static final int FIELD_CHANGE_SIGN        = 3;  // PRDY_VRSS_SIGN, 전일 대비 부호
+	public static final int FIELD_CHANGE_SIGN        = 3;  // PRDY_VRSS_SIGN, 전일 대비 부호(1:상한 2:상승 3:보합 4:하한 5:하락)
 	public static final int FIELD_CHANGE             = 4;  // PRDY_VRSS, 전일 대비
 	public static final int FIELD_CHANGE_RATE        = 5;  // PRDY_CTRT, 전일 대비율
 

--- a/src/main/java/com/back/together02be/infra/kis/constant/KisConstants.java
+++ b/src/main/java/com/back/together02be/infra/kis/constant/KisConstants.java
@@ -1,0 +1,12 @@
+package com.back.together02be.infra.kis.constant;
+
+public class KisConstants {
+	public static final String TR_REALTIME_PRICE = "H0STCNT0"; // 실시간 체결가
+
+	// H0STCNT0 수신 필드 인덱스('^' 구분)
+	public static final int FIELD_CURRENT_PRICE      = 2;  // STCK_PRPR, 주식 현재가
+	public static final int FIELD_CHANGE_SIGN        = 3;  // PRDY_VRSS_SIGN, 전일 대비 부호
+	public static final int FIELD_CHANGE             = 4;  // PRDY_VRSS, 전일 대비
+	public static final int FIELD_CHANGE_RATE        = 5;  // PRDY_CTRT, 전일 대비율
+
+}

--- a/src/main/java/com/back/together02be/infra/kis/constant/KisConstants.java
+++ b/src/main/java/com/back/together02be/infra/kis/constant/KisConstants.java
@@ -4,6 +4,7 @@ public class KisConstants {
 	public static final String TR_REALTIME_PRICE = "H0STCNT0"; // 실시간 체결가
 
 	// H0STCNT0 수신 필드 인덱스('^' 구분)
+	public static final int FIELD_STOCK_CODE    	 = 0;  // MKSC_SHRN_ISCD, 종목 코드
 	public static final int FIELD_CURRENT_PRICE      = 2;  // STCK_PRPR, 주식 현재가
 	public static final int FIELD_CHANGE_SIGN        = 3;  // PRDY_VRSS_SIGN, 전일 대비 부호
 	public static final int FIELD_CHANGE             = 4;  // PRDY_VRSS, 전일 대비

--- a/src/main/java/com/back/together02be/stock/controller/StockController.java
+++ b/src/main/java/com/back/together02be/stock/controller/StockController.java
@@ -1,7 +1,13 @@
 package com.back.together02be.stock.controller;
 
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.back.together02be.stock.service.StockService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -11,4 +17,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/stocks")
 @Tag(name = "StockController", description = "주식 API")
 public class StockController {
+
+	private final StockService stockService;
+
+	@GetMapping(value = "/{stockCode}/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter streamStockPrice(@PathVariable String stockCode) {
+		return stockService.createSseEmitter(stockCode);
+	}
 }

--- a/src/main/java/com/back/together02be/stock/dto/RealtimeStockPrice.java
+++ b/src/main/java/com/back/together02be/stock/dto/RealtimeStockPrice.java
@@ -1,0 +1,15 @@
+package com.back.together02be.stock.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RealtimeStockPrice {
+	private String stockCode;      // 종목코드
+	private String price;          // 현재가
+	private String changeSign;     // 전일 대비 부호 (1:상한 2:상승 3:보합 4:하한 5:하락)
+	private String change;         // 전일 대비
+	private String changeRate;     // 전일 대비율
+	private String tradeTime;	   // 체결시간
+}

--- a/src/main/java/com/back/together02be/stock/entity/Stock.java
+++ b/src/main/java/com/back/together02be/stock/entity/Stock.java
@@ -1,4 +1,4 @@
-package com.back.together02be.stock.enitity;
+package com.back.together02be.stock.entity;
 
 import com.back.together02be.global.entity.BaseEntity;
 

--- a/src/main/java/com/back/together02be/stock/repository/StockRepository.java
+++ b/src/main/java/com/back/together02be/stock/repository/StockRepository.java
@@ -2,7 +2,7 @@ package com.back.together02be.stock.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.back.together02be.stock.enitity.Stock;
+import com.back.together02be.stock.entity.Stock;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 }

--- a/src/main/java/com/back/together02be/stock/repository/StockRepository.java
+++ b/src/main/java/com/back/together02be/stock/repository/StockRepository.java
@@ -1,8 +1,11 @@
 package com.back.together02be.stock.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.back.together02be.stock.entity.Stock;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
+	Optional<Stock> findByStockCode(String stockCode);
 }

--- a/src/main/java/com/back/together02be/stock/service/RealTimeStockPriceStore.java
+++ b/src/main/java/com/back/together02be/stock/service/RealTimeStockPriceStore.java
@@ -1,0 +1,21 @@
+package com.back.together02be.stock.service;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+import com.back.together02be.stock.dto.RealtimeStockPrice;
+
+@Service
+public class RealTimeStockPriceStore {
+
+	private final ConcurrentHashMap<String, RealtimeStockPrice> priceMap = new ConcurrentHashMap<>();
+
+	public void put(String stockCode, RealtimeStockPrice stockPrice) {
+		priceMap.put(stockCode, stockPrice);
+	}
+
+	public RealtimeStockPrice get(String stockCode) {
+		return priceMap.get(stockCode);
+	}
+}

--- a/src/main/java/com/back/together02be/stock/service/RealTimeStockPriceStore.java
+++ b/src/main/java/com/back/together02be/stock/service/RealTimeStockPriceStore.java
@@ -1,21 +1,44 @@
 package com.back.together02be.stock.service;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.stereotype.Service;
 
 import com.back.together02be.stock.dto.RealtimeStockPrice;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Service
+@Slf4j
 public class RealTimeStockPriceStore {
 
 	private final ConcurrentHashMap<String, RealtimeStockPrice> priceMap = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, AtomicInteger> subscriberCount = new ConcurrentHashMap<>();
 
+	// 실시간 시세 넣기
 	public void put(String stockCode, RealtimeStockPrice stockPrice) {
 		priceMap.put(stockCode, stockPrice);
 	}
 
+	// 실시간 시세 꺼내기
 	public RealtimeStockPrice get(String stockCode) {
 		return priceMap.get(stockCode);
+	}
+
+	// 구독자 추가
+	public int addSubscriber(String stockCode) {
+		int count = subscriberCount.computeIfAbsent(stockCode, k -> new AtomicInteger(0)).incrementAndGet();
+		// log.info("구독자 추가 - 종목: {} | 현재 구독자 수: {}", stockCode, count);
+		return count;
+	}
+
+	// 구독자 제거-> 남은 구독자 수 반환
+	public int removeSubscriber(String stockCode) {
+		AtomicInteger count = subscriberCount.get(stockCode);
+		if (count == null) return 0;
+		int remaining = count.decrementAndGet();
+		// log.info("구독자 제거 - 종목: {} | 남은 구독자 수: {}", stockCode, remaining);
+		return remaining;
 	}
 }

--- a/src/main/java/com/back/together02be/stock/service/StockService.java
+++ b/src/main/java/com/back/together02be/stock/service/StockService.java
@@ -23,7 +23,13 @@ public class StockService {
 	private final KisWebSocketClient kisWebSocketClient;
 
 	public SseEmitter createSseEmitter(String stockCode) {
-		kisWebSocketClient.subscribe(stockCode); // 구독 요청
+
+		int count = rtStockPriceStore.addSubscriber(stockCode); // 구독자 추가
+
+		// 종목의 첫 구독자일 때만 구독 요청
+		if (count == 1) {
+			kisWebSocketClient.subscribe(stockCode);
+		}
 
 		SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
 
@@ -39,19 +45,26 @@ public class StockService {
 				emitter.complete();
 				executor.shutdown();
 			} catch (Exception e) {
-				emitter.completeWithError(e);
+				log.error("SSE 오류 - 종목: {} | 원인: {}", stockCode, e.getMessage(), e);
+				emitter.complete();
 				executor.shutdown();
 			}
 		}, 0, 1, TimeUnit.SECONDS);
 
 		emitter.onCompletion(() -> {
-			log.info("✅ SSE 연결 끊김 - 종목: {}", stockCode);  // ← 로그 추가
 			executor.shutdown();
-			kisWebSocketClient.unsubscribe(stockCode);
+			int remaining = rtStockPriceStore.removeSubscriber(stockCode);
+			if (remaining <= 0) {
+				kisWebSocketClient.unsubscribe(stockCode);  // 마지막 구독자일 때만 취소
+			}
 		});
 
 		emitter.onTimeout(() -> {
 			executor.shutdown();
+			int remaining = rtStockPriceStore.removeSubscriber(stockCode);
+			if (remaining <= 0) {
+				kisWebSocketClient.unsubscribe(stockCode);
+			}
 			log.info("SSE 타임아웃 - 종목: {}", stockCode);
 		});
 

--- a/src/main/java/com/back/together02be/stock/service/StockService.java
+++ b/src/main/java/com/back/together02be/stock/service/StockService.java
@@ -10,7 +10,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.back.together02be.infra.kis.KisWebSocketClient;
 import com.back.together02be.stock.dto.RealtimeStockPrice;
+import com.back.together02be.stock.repository.StockRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,8 +23,12 @@ public class StockService {
 
 	private final RealTimeStockPriceStore rtStockPriceStore;
 	private final KisWebSocketClient kisWebSocketClient;
+	private final StockRepository stockRepository;
 
 	public SseEmitter createSseEmitter(String stockCode) {
+
+		stockRepository.findByStockCode(stockCode)
+			.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 종목코드입니다: " + stockCode));
 
 		int count = rtStockPriceStore.addSubscriber(stockCode); // 구독자 추가
 

--- a/src/main/java/com/back/together02be/stock/service/StockService.java
+++ b/src/main/java/com/back/together02be/stock/service/StockService.java
@@ -1,10 +1,60 @@
 package com.back.together02be.stock.service;
 
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.back.together02be.infra.kis.KisWebSocketClient;
+import com.back.together02be.stock.dto.RealtimeStockPrice;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StockService {
+
+	private final RealTimeStockPriceStore rtStockPriceStore;
+	private final KisWebSocketClient kisWebSocketClient;
+
+	public SseEmitter createSseEmitter(String stockCode) {
+		kisWebSocketClient.subscribe(stockCode); // 구독 요청
+
+		SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+		executor.scheduleAtFixedRate(() -> { // (작업, 초기 지연, 주기, 단위)
+			try {
+				RealtimeStockPrice stockPrice = rtStockPriceStore.get(stockCode);
+				if (stockPrice != null) {
+					emitter.send(stockPrice);
+				}
+
+			} catch (IOException e) {
+				emitter.complete();
+				executor.shutdown();
+			} catch (Exception e) {
+				emitter.completeWithError(e);
+				executor.shutdown();
+			}
+		}, 0, 1, TimeUnit.SECONDS);
+
+		emitter.onCompletion(() -> {
+			log.info("✅ SSE 연결 끊김 - 종목: {}", stockCode);  // ← 로그 추가
+			executor.shutdown();
+			kisWebSocketClient.unsubscribe(stockCode);
+		});
+
+		emitter.onTimeout(() -> {
+			executor.shutdown();
+			log.info("SSE 타임아웃 - 종목: {}", stockCode);
+		});
+
+		return emitter;
+	}
 }

--- a/src/main/java/com/back/together02be/trade/enitity/Trade.java
+++ b/src/main/java/com/back/together02be/trade/enitity/Trade.java
@@ -3,7 +3,7 @@ package com.back.together02be.trade.enitity;
 import java.time.LocalDateTime;
 
 import com.back.together02be.global.entity.BaseEntity;
-import com.back.together02be.stock.enitity.Stock;
+import com.back.together02be.stock.entity.Stock;
 import com.back.together02be.users.enitity.Users;
 
 import jakarta.persistence.Column;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ spring:
   application:
     name: together-02-be
 
+  profiles:
+    active: local
+
   datasource:
     url: jdbc:h2:mem:db_dev;MODE=MySQL
     username: sa


### PR DESCRIPTION
## 📌 과제 설명 <특정 종목의 실시간 시세 조회>
한국투장 증권의 websocket api를 통해 특정 종목의 실시간 시세를 받고 SSE를 이용해 반환한다.
## 👩‍💻 요구 사항과 구현 내용 
feat: kis 실시간 시세 반환 필드 상수 처리, websocket 키 발급
- kis의 반환 필드를 상수로 관리
- kis의 open api websocket 키 발급 

feat: websocket 연결 및 데이터 파싱
-  websocket 연결을 통해 종목의 실시간 시세 받기
- 실시간으로 받은 일련의 데이터를 파싱

feat: 실시간 시세 인메모리 저장 후 sse 반환 
- 데이터를 받은 후 인메모리 저장
- 데이터를 sse 방식을 통해 FE에 반환
 
feat: 종목 별 구독자 관리, 마지막 구독자일 때 종목 구독 취소
- 종목별 구독자 관리, 구독 요청 관리하지 않을 경우 리소스 문제 발생.

feat: stockCode가 유효한 종목인지 확인
