### PR TITLE
Feature/st 01

### DIFF
--- a/src/main/java/com/back/together02be/stock/cache/StockPriceCache.java
+++ b/src/main/java/com/back/together02be/stock/cache/StockPriceCache.java
@@ -2,6 +2,7 @@ package com.back.together02be.stock.cache;
 
 public record StockPriceCache(
         Long currentPrice,
-        Double changeRate
+        Double changeRate,
+        Long closePrice
 ) {
 }

--- a/src/main/java/com/back/together02be/stock/client/KisPriceClient.java
+++ b/src/main/java/com/back/together02be/stock/client/KisPriceClient.java
@@ -1,9 +1,9 @@
 package com.back.together02be.stock.client;
 
+import com.back.together02be.stock.dto.KisDailyPriceRes;
 import com.back.together02be.stock.dto.KisPriceRes;
 import com.back.together02be.stock.dto.KisTokenRes;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -87,6 +87,32 @@ public class KisPriceClient {
         //예외 처리
         if (response == null || response.output() == null) {
             throw new IllegalStateException("현재가 조회 실패: stockCode=" + stockCode);
+        }
+
+        return response;
+    }
+
+    public KisDailyPriceRes getDailyPrice(String token, String stockCode) {
+
+        String url = restBaseUrl + "/uapi/domestic-stock/v1/quotations/inquire-daily-price"
+                + "?fid_cond_mrkt_div_code=J"
+                + "&fid_input_iscd=" + stockCode
+                + "&fid_org_adj_prc=1"
+                + "&fid_period_div_code=D";
+
+        KisDailyPriceRes response = restClient.get()
+                .uri(url)
+                .headers(headers -> {
+                    headers.setBearerAuth(token);
+                    headers.set("appkey", appKey);
+                    headers.set("appsecret", appSecret);
+                    headers.set("tr_id", "FHKST01010400");
+                })
+                .retrieve()
+                .body(KisDailyPriceRes.class);
+
+        if (response == null || response.output() == null) {
+            throw new IllegalStateException("종가 조회 실패: stockCode=" + stockCode);
         }
 
         return response;

--- a/src/main/java/com/back/together02be/stock/dto/KisDailyPriceRes.java
+++ b/src/main/java/com/back/together02be/stock/dto/KisDailyPriceRes.java
@@ -1,0 +1,15 @@
+//주식 현재가 일자별 API
+package com.back.together02be.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KisDailyPriceRes(
+        Output output
+) {
+    public record Output(
+
+            //종가
+            @JsonProperty("stck_clpr")
+            String closePrice
+    ) {}
+}

--- a/src/main/java/com/back/together02be/stock/service/StockService.java
+++ b/src/main/java/com/back/together02be/stock/service/StockService.java
@@ -4,6 +4,7 @@ package com.back.together02be.stock.service;
 import com.back.together02be.infra.kis.KisWebSocketClient;
 import com.back.together02be.stock.cache.StockPriceCache;
 import com.back.together02be.stock.client.KisPriceClient;
+import com.back.together02be.stock.dto.KisDailyPriceRes;
 import com.back.together02be.stock.dto.KisPriceRes;
 import com.back.together02be.stock.dto.RealtimeStockPrice;
 import com.back.together02be.stock.dto.StockListRes;
@@ -84,18 +85,26 @@ public class StockService {
         int index = currentIndex % stocks.size();
         Stock stock = stocks.get(index);
 
-            try {
-                KisPriceRes price = kisPriceClient.getCurrentPrice(token, stock.getStockCode());
+		try {
+			KisPriceRes price = kisPriceClient.getCurrentPrice(token, stock.getStockCode());
 
-                Long currentPrice = Long.parseLong(price.output().currentPrice());
-                Double changeRate = Double.parseDouble(price.output().changeRate());
+			Long currentPrice = Long.parseLong(price.output().currentPrice());
+			Double changeRate = Double.parseDouble(price.output().changeRate());
 
-                priceCache.put(stock.getStockCode(),
-                        new StockPriceCache(currentPrice, changeRate));
+			Long closePrice = null;
 
-            } catch (Exception e) {
-                System.out.println("가격 갱신 실패: " + stock.getStockCode() + " / " + e.getMessage());
-            }
+			if (currentPrice == 0) {
+				KisDailyPriceRes daily = kisPriceClient.getDailyPrice(token, stock.getStockCode());
+				closePrice = Long.parseLong(daily.output().closePrice());
+				currentPrice = closePrice;
+			}
+
+			priceCache.put(stock.getStockCode(),
+					new StockPriceCache(currentPrice, changeRate, closePrice));
+
+		} catch (Exception e) {
+			System.out.println("가격 갱신 실패: " + stock.getStockCode() + " / " + e.getMessage());
+		}
 
         // 다음 위치로 이동
         currentIndex = (currentIndex + 1) % stocks.size();


### PR DESCRIPTION
## 📌 변경 사항

- 종목 가격 조회 시 종가(closePrice) fallback 로직 추가
- StockPriceCache에 closePrice 필드 추가
- 장 종료 후 currentPrice가 0으로 내려오는 문제 해결
- stock 캐시 구조 개선

---

## 🔧 상세 내용

기존에는 한투 API에서 현재가(currentPrice)를 그대로 사용했는데,
장이 종료된 경우 currentPrice가 0으로 내려오는 문제가 있었습니다.

이를 해결하기 위해 다음과 같이 수정했습니다.

- currentPrice가 0일 경우
  → 주식현재가 일자별 API를 호출하여 종가(stck_clpr)를 가져오도록 처리
- closePrice를 캐시에 함께 저장하여 재사용 가능하도록 구조 개선

---

## ⚠️ 고려 사항

- 종가 API는 currentPrice가 0일 때만 호출하도록 하여
  API 호출 제한(초당 요청 수 제한)을 고려했습니다.
- 향후 Redis 또는 Spring Cache 적용을 통해 캐시 구조 개선 필요

---

## 🧪 테스트

- 장중: 기존 currentPrice 정상 출력 확인
- 장 종료 상황은 fallback 로직 기반으로 대응 (실제 장 종료 후 추가 검증 예정)
