### PR TITLE
feat(stock): 캐시 기반 단일 종목 가격 조회

### DIFF
--- a/src/main/java/com/back/together02be/stock/controller/StockController.java
+++ b/src/main/java/com/back/together02be/stock/controller/StockController.java
@@ -1,24 +1,18 @@
 package com.back.together02be.stock.controller;
 
-import java.util.List;
-
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
 import com.back.together02be.global.apiRes.ApiRes;
 import com.back.together02be.stock.dto.StockListRes;
 import com.back.together02be.stock.dto.response.StockPriceRes;
 import com.back.together02be.stock.service.StockService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
 
 @CrossOrigin(origins = "http://localhost:3000")
 @RestController

--- a/src/main/java/com/back/together02be/stock/service/StockService.java
+++ b/src/main/java/com/back/together02be/stock/service/StockService.java
@@ -43,6 +43,10 @@ public class StockService {
 
     private int currentIndex = 0;
 
+	public StockPriceCache getCachedStockPrice(String stockCode) {
+		return priceCache.get(stockCode);
+	}
+
     //캐시 읽는 메서드
     public List<StockListRes> getStocks() {
         List<StockListRes> result = new ArrayList<>();


### PR DESCRIPTION
## 📌 작업 내용
- StockService에 getCachedStockPrice 메서드 추가
- 캐시에 저장된 단일 종목의 현재가/등락률 조회 기능 구현

## 💡 변경 이유
- 전체 종목 조회(getStocks) 외에 특정 종목의 현재가만 조회할 수 있는 기능 필요
- DB 조회가 아닌 캐시 기반으로 빠르게 조회할 수 있도록 분리

## 🔧 주요 변경 사항
- getCachedStockPrice(String stockCode) 메서드 추가
