### PR TITLE
Feature/st 05

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.13.0")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
+
+    implementation ("org.springframework.boot:spring-boot-starter-cache")
+    implementation ("com.github.ben-manes.caffeine:caffeine")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/together02be/Together02BeApplication.java
+++ b/src/main/java/com/back/together02be/Together02BeApplication.java
@@ -2,12 +2,14 @@ package com.back.together02be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableCaching
 public class Together02BeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/back/together02be/chart/constant/ChartPeriod.java
+++ b/src/main/java/com/back/together02be/chart/constant/ChartPeriod.java
@@ -1,0 +1,33 @@
+package com.back.together02be.chart.constant;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+import lombok.Getter;
+
+@Getter
+public enum ChartPeriod {
+	THREE_MONTHS("3M", "D", 90),
+	ONE_YEAR("1Y", "W", 365);
+
+	private final String value;
+	private final String kisPeriodCode;
+	private final int lookbackDays;
+
+	ChartPeriod(String value, String kisPeriodCode, int lookbackDays) {
+		this.value = value;
+		this.kisPeriodCode = kisPeriodCode;
+		this.lookbackDays = lookbackDays;
+	}
+
+	public static ChartPeriod from(String value) {
+		return Arrays.stream(values())
+			.filter(p -> p.value.equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("지원하지 않는 기간: " + value));
+	}
+
+	public LocalDate startDate(LocalDate endDate) {
+		return endDate.minusDays(lookbackDays);
+	}
+}

--- a/src/main/java/com/back/together02be/chart/controller/ChartController.java
+++ b/src/main/java/com/back/together02be/chart/controller/ChartController.java
@@ -1,0 +1,30 @@
+package com.back.together02be.chart.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.together02be.chart.dto.response.ChartRes;
+import com.back.together02be.chart.service.ChartService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/stocks/{stockCode}/chart")
+@RequiredArgsConstructor
+public class ChartController {
+	private final ChartService chartService;
+
+	@GetMapping
+	@Operation(summary = "특정 종목 차트 조회")
+	public ResponseEntity<ChartRes> getChart(
+		@PathVariable String stockCode,
+		@RequestParam(defaultValue = "3M") String period
+	) {
+		return ResponseEntity.ok(chartService.getChart(stockCode, period));
+	}
+}

--- a/src/main/java/com/back/together02be/chart/dto/Candle.java
+++ b/src/main/java/com/back/together02be/chart/dto/Candle.java
@@ -1,0 +1,14 @@
+package com.back.together02be.chart.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record Candle(
+	LocalDate date,
+	BigDecimal open,
+	BigDecimal high,
+	BigDecimal low,
+	BigDecimal close,
+	Long volume
+) {
+}

--- a/src/main/java/com/back/together02be/chart/dto/response/CandleRes.java
+++ b/src/main/java/com/back/together02be/chart/dto/response/CandleRes.java
@@ -1,0 +1,21 @@
+package com.back.together02be.chart.dto.response;
+
+import java.math.BigDecimal;
+
+import com.back.together02be.chart.dto.Candle;
+
+public record CandleRes(
+	String time,
+	BigDecimal open,
+	BigDecimal high,
+	BigDecimal low,
+	BigDecimal close,
+	Long volume
+) {
+	public static CandleRes from(Candle candle) {
+		return new CandleRes(
+			candle.date().toString(), // yyyy-MM-dd
+			candle.open(), candle.high(), candle.low(), candle.close(), candle.volume()
+		);
+	}
+}

--- a/src/main/java/com/back/together02be/chart/dto/response/ChartRes.java
+++ b/src/main/java/com/back/together02be/chart/dto/response/ChartRes.java
@@ -1,0 +1,20 @@
+package com.back.together02be.chart.dto.response;
+
+import java.util.List;
+
+import com.back.together02be.chart.constant.ChartPeriod;
+import com.back.together02be.chart.dto.Candle;
+
+public record ChartRes(
+	String stockCode,
+	String name,
+	String period,
+	String interval,
+	List<CandleRes> candles
+) {
+	public static ChartRes of(String stockCode, String name, ChartPeriod period, List<Candle> candles) {
+		List<CandleRes> dtos = candles.stream().map(CandleRes::from).toList();
+		return new ChartRes(stockCode, name, period.getValue(),
+			period == ChartPeriod.THREE_MONTHS ? "DAY" : "WEEK", dtos);
+	}
+}

--- a/src/main/java/com/back/together02be/chart/dto/response/KisChartApiRes.java
+++ b/src/main/java/com/back/together02be/chart/dto/response/KisChartApiRes.java
@@ -1,0 +1,25 @@
+package com.back.together02be.chart.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KisChartApiRes(
+	@JsonProperty("rt_cd")  String rtCd, // "0"이면 성공
+	@JsonProperty("msg1")   String msg1, // 에러 메시지
+	@JsonProperty("output1") Output1 output1,
+	@JsonProperty("output2") List<Output2> output2
+) {
+	public record Output1(
+		@JsonProperty("hts_kor_isnm") String htsKorIsnm
+	) {}
+
+	public record Output2(
+		@JsonProperty("stck_bsop_date") String stckBsopDate,  // 날짜 yyyyMMdd
+		@JsonProperty("stck_oprc")      String stckOprc,       // 시가
+		@JsonProperty("stck_hgpr")      String stckHgpr,       // 고가
+		@JsonProperty("stck_lwpr")      String stckLwpr,       // 저가
+		@JsonProperty("stck_clpr")      String stckClpr,       // 종가
+		@JsonProperty("acml_vol")       String acmlVol         // 거래량
+	) {}
+}

--- a/src/main/java/com/back/together02be/chart/scheduler/ChartCacheScheduler.java
+++ b/src/main/java/com/back/together02be/chart/scheduler/ChartCacheScheduler.java
@@ -1,0 +1,32 @@
+package com.back.together02be.chart.scheduler;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChartCacheScheduler {
+
+	private final CacheManager cacheManager;
+
+	/*
+		15:30 장 마감 -> 당일 캔들 확정
+		이때 캐시 비워야 다음 요청에 최신 데이터 반영
+
+		토/일은 장이 없으니 스케줄러 돌릴 필요 없음
+		월 ~ 금만 실행
+	*/
+
+	// @Scheduled(cron = "0 * * * * *") 테스트
+	@Scheduled(cron = "0 30 15 * * MON-FRI") // 평일 15:30
+	public void clearChartCache() {
+		cacheManager.getCache("chart").clear();
+		log.info("차트 캐시 장 마감 캐시 초기화 완료");
+	}
+
+}

--- a/src/main/java/com/back/together02be/chart/service/ChartService.java
+++ b/src/main/java/com/back/together02be/chart/service/ChartService.java
@@ -31,7 +31,7 @@ public class ChartService {
 
 		ChartPeriod period = ChartPeriod.from(periodValue);
 
-		log.debug("종목 차트 캐시 미스 → KIS API 호출 - stockCode={}, period={}", stockCode, periodValue);
+		log.info("종목 차트 캐시 미스 → KIS API 호출 - stockCode={}, period={}", stockCode, periodValue);
 		KisChartApiRes response = kisPriceClient.fetchCandles(stockCode, period);
 
 		List<Candle> candles = response.output2().stream()

--- a/src/main/java/com/back/together02be/chart/service/ChartService.java
+++ b/src/main/java/com/back/together02be/chart/service/ChartService.java
@@ -1,0 +1,57 @@
+package com.back.together02be.chart.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import com.back.together02be.chart.constant.ChartPeriod;
+import com.back.together02be.chart.dto.Candle;
+import com.back.together02be.chart.dto.response.ChartRes;
+import com.back.together02be.chart.dto.response.KisChartApiRes;
+import com.back.together02be.stock.client.KisPriceClient;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChartService {
+
+	private final KisPriceClient kisPriceClient;
+
+	@Cacheable(value = "chart", key = "#stockCode + ':' + #periodValue")
+	public ChartRes getChart(String stockCode, String periodValue) {
+
+		ChartPeriod period = ChartPeriod.from(periodValue);
+
+		log.debug("종목 차트 캐시 미스 → KIS API 호출 - stockCode={}, period={}", stockCode, periodValue);
+		KisChartApiRes response = kisPriceClient.fetchCandles(stockCode, period);
+
+		List<Candle> candles = response.output2().stream()
+			.map(o -> new Candle(
+				LocalDate.parse(o.stckBsopDate(), DateTimeFormatter.BASIC_ISO_DATE),
+				new BigDecimal(o.stckOprc()),
+				new BigDecimal(o.stckHgpr()),
+				new BigDecimal(o.stckLwpr()),
+				new BigDecimal(o.stckClpr()),
+				Long.parseLong(o.acmlVol())
+			))
+			.sorted(Comparator.comparing(Candle::date))
+			.toList();
+
+		if (candles.isEmpty()) {
+			throw new EntityNotFoundException("종목 데이터를 찾을 수 없습니다: " + stockCode);
+		}
+
+		String stockName = response.output1() != null ? response.output1().htsKorIsnm() : "";
+
+		return ChartRes.of(stockCode, stockName, period, candles);
+	}
+}

--- a/src/main/java/com/back/together02be/stock/client/KisPriceClient.java
+++ b/src/main/java/com/back/together02be/stock/client/KisPriceClient.java
@@ -1,14 +1,19 @@
 package com.back.together02be.stock.client;
 
-import com.back.together02be.stock.dto.KisPriceRes;
-import com.back.together02be.stock.dto.KisTokenRes;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-import java.util.Map;
+import com.back.together02be.chart.constant.ChartPeriod;
+import com.back.together02be.chart.dto.response.KisChartApiRes;
+import com.back.together02be.stock.dto.KisPriceRes;
+import com.back.together02be.stock.dto.KisTokenRes;
 
 @Component
 public class KisPriceClient {
@@ -87,6 +92,43 @@ public class KisPriceClient {
         //예외 처리
         if (response == null || response.output() == null) {
             throw new IllegalStateException("현재가 조회 실패: stockCode=" + stockCode);
+        }
+
+        return response;
+    }
+
+    public KisChartApiRes fetchCandles(String stockCode, ChartPeriod period) {
+        String token = getAccessToken();
+
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = period.startDate(endDate);
+
+        String url = restBaseUrl
+            + "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice"
+            + "?FID_COND_MRKT_DIV_CODE=J"
+            + "&FID_INPUT_ISCD=" + stockCode
+            + "&FID_INPUT_DATE_1=" + startDate.format(DateTimeFormatter.BASIC_ISO_DATE)
+            + "&FID_INPUT_DATE_2=" + endDate.format(DateTimeFormatter.BASIC_ISO_DATE)
+            + "&FID_PERIOD_DIV_CODE=" + period.getKisPeriodCode()
+            + "&FID_ORG_ADJ_PRC=0";
+
+        KisChartApiRes response = restClient.get()
+            .uri(url)
+            .headers(headers -> {
+                headers.setBearerAuth(token);
+                headers.set("appkey", appKey);
+                headers.set("appsecret", appSecret);
+                headers.set("tr_id", "FHKST03010100");
+                headers.set("custtype", "P");
+            })
+            .retrieve()
+            .onStatus(HttpStatusCode::isError, (req, res) -> {
+                throw new IllegalStateException("KIS 차트 API 호출 실패: HTTP " + res.getStatusCode());
+            })
+            .body(KisChartApiRes.class);
+
+        if (response == null || response.output2() == null || response.output2().isEmpty()) {
+            throw new IllegalStateException("KIS 차트 응답이 비어있습니다: code=" + stockCode);
         }
 
         return response;

--- a/src/main/java/com/back/together02be/stock/service/StockService.java
+++ b/src/main/java/com/back/together02be/stock/service/StockService.java
@@ -1,5 +1,17 @@
 package com.back.together02be.stock.service;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.back.together02be.infra.kis.KisWebSocketClient;
 import com.back.together02be.stock.cache.StockPriceCache;
@@ -10,96 +22,86 @@ import com.back.together02be.stock.dto.StockListRes;
 import com.back.together02be.stock.dto.response.StockPriceRes;
 import com.back.together02be.stock.entity.Stock;
 import com.back.together02be.stock.repository.StockRepository;
+
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class StockService {
 
-    private final StockRepository stockRepository;
-    private final KisPriceClient kisPriceClient;
+	private final StockRepository stockRepository;
+	private final KisPriceClient kisPriceClient;
 
 	//SSE용
 	private final RealTimeStockPriceStore rtStockPriceStore;
 	private final KisWebSocketClient kisWebSocketClient;
 
 	// REST 전체 종목 조회용 캐시
-    private final Map<String, StockPriceCache> priceCache = new ConcurrentHashMap<>();
+	private final Map<String, StockPriceCache> priceCache = new ConcurrentHashMap<>();
 
-    private int currentIndex = 0;
+	private int currentIndex = 0;
 
-    //캐시 읽는 메서드
-    public List<StockListRes> getStocks() {
-        List<StockListRes> result = new ArrayList<>();
+	//캐시 읽는 메서드
+	public List<StockListRes> getStocks() {
+		List<StockListRes> result = new ArrayList<>();
 
-        for (Stock stock : stockRepository.findAll()) {
-            StockPriceCache cached = priceCache.get(stock.getStockCode());
+		for (Stock stock : stockRepository.findAll()) {
+			StockPriceCache cached = priceCache.get(stock.getStockCode());
 
-            Long currentPrice = null;
-            Double changeRate = null;
+			Long currentPrice = null;
+			Double changeRate = null;
 
-            if (cached != null) {
-                currentPrice = cached.currentPrice();
-                changeRate = cached.changeRate();
-            }
+			if (cached != null) {
+				currentPrice = cached.currentPrice();
+				changeRate = cached.changeRate();
+			}
 
-            result.add(new StockListRes(
-                    stock.getId(),
-                    stock.getStockCode(),
-                    stock.getStockName(),
-                    currentPrice,
-                    changeRate
-            ));
-        }
+			result.add(new StockListRes(
+				stock.getId(),
+				stock.getStockCode(),
+				stock.getStockName(),
+				currentPrice,
+				changeRate
+			));
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    //스케줄러 메서드
-    @Scheduled(fixedDelay = 1000) // 1초마다
-    public void updatePriceCache() {
+	//스케줄러 메서드
+	@Scheduled(fixedDelay = 1000) // 1초마다
+	public void updatePriceCache() {
 
-        List<Stock> stocks = stockRepository.findAll();
+		List<Stock> stocks = stockRepository.findAll();
 
-        if (stocks.isEmpty()) return;
+		if (stocks.isEmpty())
+			return;
 
-        String token = kisPriceClient.getAccessToken();
+		String token = kisPriceClient.getAccessToken();
 
-        // 한투 OpenAPI 호출 제한 때문에 전체 종목을 한 번에 갱신하지 않고 순차 갱신
-        int index = currentIndex % stocks.size();
-        Stock stock = stocks.get(index);
+		// 한투 OpenAPI 호출 제한 때문에 전체 종목을 한 번에 갱신하지 않고 순차 갱신
+		int index = currentIndex % stocks.size();
+		Stock stock = stocks.get(index);
 
-            try {
-                KisPriceRes price = kisPriceClient.getCurrentPrice(token, stock.getStockCode());
+		try {
+			KisPriceRes price = kisPriceClient.getCurrentPrice(token, stock.getStockCode());
 
-                Long currentPrice = Long.parseLong(price.output().currentPrice());
-                Double changeRate = Double.parseDouble(price.output().changeRate());
+			Long currentPrice = Long.parseLong(price.output().currentPrice());
+			Double changeRate = Double.parseDouble(price.output().changeRate());
 
-                priceCache.put(stock.getStockCode(),
-                        new StockPriceCache(currentPrice, changeRate));
+			priceCache.put(stock.getStockCode(),
+				new StockPriceCache(currentPrice, changeRate));
 
-            } catch (Exception e) {
-                System.out.println("가격 갱신 실패: " + stock.getStockCode() + " / " + e.getMessage());
-            }
+		} catch (Exception e) {
+			System.out.println("가격 갱신 실패: " + stock.getStockCode() + " / " + e.getMessage());
+		}
 
-        // 다음 위치로 이동
-        currentIndex = (currentIndex + 1) % stocks.size();
-    }
+		// 다음 위치로 이동
+		currentIndex = (currentIndex + 1) % stocks.size();
+	}
 
 
 	public SseEmitter createSseEmitter(String stockCode) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,12 @@ spring:
     active: local
     include: secret
 
+  cache:
+    type: caffeine
+    cache-names: chart
+    caffeine:
+      spec: maximumSize=60,expireAfterWrite=24h # 모의투자 종목 20개 × 기간 2개(3M, 1Y) = 최대 40개 넉넉히 60개
+
   datasource:
     url: jdbc:h2:mem:db_dev;MODE=MySQL
     username: sa
@@ -23,7 +29,7 @@ spring:
         highlight_sql: true
         use_sql_comments: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     defer-datasource-initialization: true
 
@@ -36,6 +42,6 @@ springdoc:
 
 logging:
   level:
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.orm.jdbc.extract: TRACE
-    org.springframework.transaction.interceptor: TRACE
+    org.hibernate.orm.jdbc.bind: INFO
+    org.hibernate.orm.jdbc.extract: INFO
+    org.springframework.transaction.interceptor: INFO


### PR DESCRIPTION
## 📌 과제 설명 <특정 종목 차트 조회>
특정 종목 차트 조회
특정 종목 차트 종목 카페인 캐싱을 이용해 구현
주식장 종료시 당일 차트 정보 동기화를 위해 캐싱 초기화 스케줄링

## 👩‍💻 요구 사항과 구현 내용
feat: 특정 종목 차트 3M, 1Y기간 조회
3개월 1년 차트 정보 조회 구현

feat: 차트 캐시 초기화(스케줄러)
주식장 종료 시 당일 캔들 정보로 동기화되도록 캐시 초기화 스케줄링