### PR TITLE
Feature/pf 02

### DIFF
--- a/src/main/java/com/back/together02be/asset/controller/AssetController.java
+++ b/src/main/java/com/back/together02be/asset/controller/AssetController.java
@@ -1,22 +1,22 @@
 package com.back.together02be.asset.controller;
 
+import com.back.together02be.asset.dto.response.StockInfoRes;
+import com.back.together02be.asset.dto.response.TotalPurchaseRes;
 import com.back.together02be.asset.dto.response.UserStockRes;
 import com.back.together02be.asset.service.AssetService;
 import com.back.together02be.global.apiRes.ApiRes;
 import com.back.together02be.global.security.SecurityUser;
-import io.swagger.v3.oas.annotations.Operation;
-
-import com.back.together02be.asset.dto.response.StockInfoRes;
-import com.back.together02be.asset.dto.response.TotalPurchaseRes;
 import com.back.together02be.users.service.UsersService;
-import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -29,11 +29,19 @@ public class AssetController {
     private final AssetService assetService;
     private final UsersService usersService;
 
+    // 초기 데이터 조회 (REST API)
     @GetMapping("/stocks")
-    @Operation(summary = "보유 종목 조회")
+    @Operation(summary = "보유 종목 초기 데이터 조회")
     public ResponseEntity<ApiRes<List<UserStockRes>>> getUserStocks(@AuthenticationPrincipal SecurityUser user) {
         List<UserStockRes> userStocks = assetService.getUserStocks(user.getId());
         return ResponseEntity.ok(new ApiRes<>("보유 종목 조회 성공", userStocks));
+    }
+
+    // 실시간 시세 구독 (SSE)
+    @GetMapping(value = "/stocks/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Operation(summary = "보유 종목 실시간 시세 구독")
+    public SseEmitter subscribeUserStocks(@AuthenticationPrincipal SecurityUser user) {
+        return assetService.subscribeToUserStocks(user.getId());
     }
 
     @GetMapping("/accounts")

--- a/src/main/java/com/back/together02be/asset/controller/AssetController.java
+++ b/src/main/java/com/back/together02be/asset/controller/AssetController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/back/together02be/asset/dto/response/UserStockRes.java
+++ b/src/main/java/com/back/together02be/asset/dto/response/UserStockRes.java
@@ -6,14 +6,17 @@ public record UserStockRes(
         String stockCode,
         String stockName,
         Long quantity,
-        Long averagePrice
+        Long averagePrice,
+        Long currentPrice
 ) {
-    public static UserStockRes from(UserStock userStock) {
+    public static UserStockRes from(UserStock userStock,Long currentPrice) {
         return new UserStockRes(
                 userStock.getStock().getStockCode(),
                 userStock.getStock().getStockName(),
                 userStock.getQuantity(),
-                userStock.getAveragePrice()
+                userStock.getAveragePrice(),
+                currentPrice
+
         );
     }
 }

--- a/src/main/java/com/back/together02be/asset/service/AssetService.java
+++ b/src/main/java/com/back/together02be/asset/service/AssetService.java
@@ -1,16 +1,20 @@
 package com.back.together02be.asset.service;
 
 import com.back.together02be.asset.dto.response.UserStockRes;
+import com.back.together02be.asset.entity.UserStock;
 import com.back.together02be.asset.repository.UserStockRepository;
+import com.back.together02be.stock.service.StockService;
 import org.springframework.stereotype.Service;
 
 import com.back.together02be.asset.dto.response.StockInfoRes;
 import com.back.together02be.asset.entity.UserStock;
 import com.back.together02be.asset.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -18,11 +22,24 @@ import java.util.List;
 public class AssetService {
     private final UserAccountRepository userAccountRepository;
     private final UserStockRepository userStockRepository;
+    private final StockService stockService;
 
     public List<UserStockRes> getUserStocks(Long userId) {
-        return userStockRepository.findAllByUsersId(userId).stream()
-                .map(UserStockRes::from)
-                .toList();
+        //보유 주식 목록 조회
+        List<UserStock> userStocks = userStockRepository.findAllByUsersId(userId);
+        return getUserStocksRealtimePrice(userStocks);
+    }
+
+    // 유저 보유 종목 현재 시세 조회
+    public List<UserStockRes> getUserStocksRealtimePrice(List<UserStock> userStocks) {
+
+        return userStocks.stream().map(userStock -> {
+            String stockCode = userStock.getStock().getStockCode();
+            Long currentPrice = stockService.getCachedStockPrice(stockCode).currentPrice();
+
+
+            return UserStockRes.from(userStock, currentPrice);
+        }).collect(Collectors.toList());
     }
     public long getTotalAmountByUserId(long userId){
         return userAccountRepository.findByUsersId(userId)

--- a/src/main/java/com/back/together02be/asset/service/AssetService.java
+++ b/src/main/java/com/back/together02be/asset/service/AssetService.java
@@ -1,29 +1,32 @@
 package com.back.together02be.asset.service;
 
+import com.back.together02be.asset.dto.response.StockInfoRes;
 import com.back.together02be.asset.dto.response.UserStockRes;
 import com.back.together02be.asset.entity.UserStock;
-import com.back.together02be.asset.repository.UserStockRepository;
-import com.back.together02be.stock.service.StockService;
-import org.springframework.stereotype.Service;
-
-import com.back.together02be.asset.dto.response.StockInfoRes;
-import com.back.together02be.asset.entity.UserStock;
 import com.back.together02be.asset.repository.UserAccountRepository;
+import com.back.together02be.asset.repository.UserStockRepository;
+import com.back.together02be.stock.dto.RealtimeStockPrice;
+import com.back.together02be.stock.service.RealTimeStockPriceStore;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AssetService {
     private final UserAccountRepository userAccountRepository;
     private final UserStockRepository userStockRepository;
-    private final StockService stockService;
+    private final RealTimeStockPriceStore realTimeStockPriceStore;
+    private final UserStockSseService userStockSseService;
 
+    // 보유 종목 조회 메서드
     public List<UserStockRes> getUserStocks(Long userId) {
         //보유 주식 목록 조회
         List<UserStock> userStocks = userStockRepository.findAllByUsersId(userId);
@@ -35,7 +38,11 @@ public class AssetService {
 
         return userStocks.stream().map(userStock -> {
             String stockCode = userStock.getStock().getStockCode();
-            Long currentPrice = stockService.getCachedStockPrice(stockCode).currentPrice();
+            // RealTimeStockPriceStore의 get 메서드를 사용하여 실시간 시세 조회
+            RealtimeStockPrice realtimeStockPrice = realTimeStockPriceStore.get(stockCode);
+
+            // Map에 아직 데이터가 적재되지 않아 null을 반환할 경우를 대비한 방어 로직
+            Long currentPrice = (realtimeStockPrice != null) ? Long.parseLong(realtimeStockPrice.getPrice()) : 0L;
 
 
             return UserStockRes.from(userStock, currentPrice);
@@ -54,5 +61,42 @@ public class AssetService {
                 .toList();
 
         return stockInfos;
+    }
+
+    // SSE 다중 종목 구독
+    public SseEmitter subscribeToUserStocks(Long userId) {
+        List<UserStock> userStocks = userStockRepository.findAllByUsersId(userId);
+        List<String> stockCodes = userStocks.stream().map(s->s.getStock().getStockCode()).toList();
+
+        SseEmitter emitter = userStockSseService.createEmitter();
+
+        // 💡 만약 보유 주식이 없다면, 503 에러를 막기 위해 연결 더미 데이터만 보내고 유지합니다.
+        if (stockCodes.isEmpty()) {
+            try {
+                emitter.send(SseEmitter.event().name("CONNECT").data("no_stocks"));
+            } catch (IOException e) {
+                emitter.completeWithError(e);
+            }
+            return emitter;
+        }
+
+        stockCodes.forEach(code -> userStockSseService.addEmitter(code, emitter));
+
+        Runnable onCompletion = () -> {
+            stockCodes.forEach(code -> userStockSseService.removeEmitter(code, emitter));
+        };
+
+        emitter.onCompletion(onCompletion);
+        emitter.onTimeout(onCompletion);
+        emitter.onError((e) -> onCompletion.run());
+
+        // 💡 503 에러 방지용 첫 이벤트 전송
+        try {
+            emitter.send(SseEmitter.event().name("CONNECT").data("connected"));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
     }
 }

--- a/src/main/java/com/back/together02be/asset/service/UserStockSseService.java
+++ b/src/main/java/com/back/together02be/asset/service/UserStockSseService.java
@@ -1,0 +1,65 @@
+package com.back.together02be.asset.service;
+
+import com.back.together02be.stock.dto.RealtimeStockPrice;
+import com.back.together02be.stock.service.RealTimeStockPriceStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserStockSseService {
+    private final Map<String, List<SseEmitter>> emittersMap = new ConcurrentHashMap<>();
+
+    public SseEmitter createEmitter() {
+        return new SseEmitter(10 * 60 * 1000L);
+    }
+
+    public void addEmitter(String stockCode, SseEmitter emitter) {
+        emittersMap.computeIfAbsent(stockCode, k -> new CopyOnWriteArrayList<>()).add(emitter);
+    }
+
+    public void removeEmitter(String stockCode, SseEmitter emitter) {
+        List<SseEmitter> emitters = emittersMap.get(stockCode);
+        if (emitters != null) emitters.remove(emitter);
+    }
+
+    // 캐시에서 현재가를 가져오기 위해 주입
+    private final RealTimeStockPriceStore priceStore;
+
+
+
+    // 💡 핵심 로직: 1.5초마다 현재 구독 중인 종목들의 시세만 꺼내서 구독자들에게 전송
+    @Scheduled(fixedRate = 1500)
+    public void broadcastOwnedStocks() {
+        if (emittersMap.isEmpty()) return;
+
+        // 현재 누군가 화면에서 보고 있는(구독 중인) 종목 코드들만 순회
+        emittersMap.forEach((stockCode, emitters) -> {
+            if (emitters.isEmpty()) return;
+
+            // 저장소에서 해당 종목의 최신 가격 조회
+            RealtimeStockPrice currentPrice = priceStore.get(stockCode);
+
+            if (currentPrice != null) {
+
+                // 해당 종목을 보유한(구독 중인) 모든 유저에게 한 번에 전송
+                emitters.forEach(emitter -> {
+                    try {
+                        emitter.send(SseEmitter.event().name("priceUpdate").data(currentPrice));
+                    } catch (Exception e) {
+                        removeEmitter(stockCode, emitter);
+                    }
+                });
+            }
+        });
+    }
+}

--- a/src/main/java/com/back/together02be/global/initData/BaseInitData.java
+++ b/src/main/java/com/back/together02be/global/initData/BaseInitData.java
@@ -1,5 +1,19 @@
 package com.back.together02be.global.initData;
 
+import com.back.together02be.asset.entity.UserAccount;
+import com.back.together02be.asset.entity.UserStock;
+import com.back.together02be.asset.repository.UserAccountRepository;
+import com.back.together02be.asset.repository.UserStockRepository;
+import com.back.together02be.stock.entity.Stock;
+import com.back.together02be.stock.entity.StockMarket;
+import com.back.together02be.stock.repository.StockRepository;
+import com.back.together02be.stock.service.StockService;
+import com.back.together02be.users.dto.request.SignupReq;
+import com.back.together02be.users.entity.Users;
+import com.back.together02be.users.repository.UsersRepository;
+import com.back.together02be.users.service.UsersService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
@@ -8,18 +22,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.back.together02be.asset.entity.UserAccount;
-import com.back.together02be.asset.repository.UserAccountRepository;
-import com.back.together02be.stock.entity.Stock;
-import com.back.together02be.stock.entity.StockMarket;
-import com.back.together02be.stock.repository.StockRepository;
-import com.back.together02be.users.dto.request.SignupReq;
-import com.back.together02be.users.entity.Users;
-import com.back.together02be.users.repository.UsersRepository;
-import com.back.together02be.users.service.UsersService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -36,6 +39,8 @@ public class BaseInitData {
     private BaseInitData self;
 
     private final UsersService usersService;
+    private final UserStockRepository userStockRepository;
+    private final StockService stockService;
 
     @Bean
     public ApplicationRunner initData() {
@@ -43,6 +48,7 @@ public class BaseInitData {
             self.work1();
             self.work2();
             self.work3();
+            self.work4();
         };
     }
 
@@ -60,7 +66,7 @@ public class BaseInitData {
         }
 
         Users user = usersRepository.save(new Users("testuser", passwordEncoder.encode("password1234"), "테스트유저"));
-        
+
         userAccountRepository.save(new UserAccount(user, 0L, 50_000_000L));
     }
 
@@ -101,6 +107,19 @@ public class BaseInitData {
         stockRepository.save(new Stock("006400", "삼성SDI", StockMarket.KOSPI));
         stockRepository.save(new Stock("207940", "삼성바이오로직스", StockMarket.KOSPI));
         stockRepository.save(new Stock("373220", "LG에너지솔루션", StockMarket.KOSPI));
+    }
+
+    @Transactional
+    public void work4() {
+
+        List<Stock> stocks = stockRepository.findAll();
+
+        usersRepository.findAll().stream().forEach(user->{
+            for(int i=0;i<5;i++){
+                userStockRepository.save(new UserStock(user,stocks.get(i),33L,343423L));
+            }
+
+        });
     }
 
 }

--- a/src/main/java/com/back/together02be/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/together02be/global/security/CustomAuthenticationFilter.java
@@ -33,17 +33,23 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        // 헤더에서 토큰 꺼냄
-        String authHeader = request.getHeader("Authorization");
+        String token = null;
 
-        // 토큰 없으면 그냥 통과
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        // 1. 헤더에서 토큰 추출 시도
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            token = authHeader.substring(7); // "Bearer " 이후의 순수 토큰만 추출
+        }
+        // 2. 헤더에 없다면 URL 파라미터에서 추출 시도
+        else {
+            token = request.getParameter("token"); // 파라미터는 "Bearer "가 없으므로 그대로 사용
+        }
+
+        // 3. 둘 다 없으면 검증 없이 통과 (SecurityConfig의 인가 설정에 맡김)
+        if (token == null || token.isBlank()) {
             filterChain.doFilter(request, response);
             return;
         }
-
-        // "Bearer eyJhbGciOiJIUzI1NiJ9..." -> 7부터 토큰
-        String token = authHeader.substring(7);
 
         Map<String, Object> payload = JwtUtil.payloadOrNull(token, jwtSecret);
 


### PR DESCRIPTION
## 📌 과제 설명 
보유 종목 실시간 현재가 수신 api 추가

## 👩‍💻 요구 사항과 구현 내용

feat: 보유 종목 목록 현재가 포함 응답 하도록 수정
feat: 보유 종목 실시간 현재가 수신 로직 수정 및 엔드포인트 분리
feat: 인증 필요 sse 기능을 위해 요청 시 url 에서도 토큰 추출 할 수 있도록 수정
feat: 실시간 현재가 수신 로직 구현
feat: 보유 종목 실시간 현재가 수신 테스트 initData 추가

## ✅ 피드백 반영사항 
보유 종목 정보 조회와 보유 종목 실시간 현재가 조회 api 분리
